### PR TITLE
git@2.39.0.windows.2: update notes

### DIFF
--- a/bucket/git.json
+++ b/bucket/git.json
@@ -3,7 +3,7 @@
     "description": "Distributed version control system",
     "homepage": "https://gitforwindows.org",
     "license": "GPL-2.0-only",
-    "notes": "Set Git Credential Manager Core by running: \"git config --global credential.helper manager-core\"",
+    "notes": "Set Git Credential Manager Core by running: \"git config --global credential.helper manager\"",
     "architecture": {
         "64bit": {
             "url": "https://github.com/git-for-windows/git/releases/download/v2.39.0.windows.2/PortableGit-2.39.0.2-64-bit.7z.exe#/dl.7z",


### PR DESCRIPTION
Resolve warning when using git:
warning: git-credential-manager-core was renamed to git-credential-manager
warning: see https://aka.ms/gcm/rename for more information

- [ ] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
